### PR TITLE
Reflect CompositeNode constructur signature changes

### DIFF
--- a/src/main/java/org/geppetto/testbackend/services/DummySimulatorService.java
+++ b/src/main/java/org/geppetto/testbackend/services/DummySimulatorService.java
@@ -291,7 +291,7 @@ public class DummySimulatorService extends ASimulator
 	 * Create Time Tree
 	 */
 	private void updateTimeNode(){
-		ACompositeNode time = new CompositeNode();
+		ACompositeNode time = new CompositeNode("dummyID");
 
 		if(time.getChildren().size() == 0){
 			PhysicalQuantity stepQ = new PhysicalQuantity();


### PR DESCRIPTION
Fix compilation error in development branch of testbackend:

```
[ERROR]     /Users/dk/development/projects/openworm/geppetto/org.geppetto.testbackend/src/main/java/org/geppetto/testbackend/services/DummySimulatorService.java:[294,39] no suitable constructor found for CompositeNode()
constructor     org.geppetto.core.model.runtime.CompositeNode.CompositeNode(java.lang.String,java.lang.String) is not applicable
  (actual and formal argument lists differ in length)
constructor org.geppetto.core.model.runtime.CompositeNode.CompositeNode(java.lang.String) is not applicable
  (actual and formal argument lists differ in length)
[INFO] 1 error
```
